### PR TITLE
fix tutorial notebook title

### DIFF
--- a/docs/tutorials/Changepoints-Time-Series.ipynb
+++ b/docs/tutorials/Changepoints-Time-Series.ipynb
@@ -5,7 +5,7 @@
    "id": "bb06961a-3e8c-44b8-9c82-290ef3466706",
    "metadata": {},
    "source": [
-    "# Generate patterns in time series"
+    "# Generate changepoints in time series"
    ]
   },
   {


### PR DESCRIPTION
the tutorial notebook had the wrong title, leading to a mistake in the auto-generated documentation page for change point generation in time series.

- change title to "Generate changepoints in time series"